### PR TITLE
CRS-1849: Support any iso format in hmppsFormatDate filter

### DIFF
--- a/docs/components/court-cases-release-dates/latest-calculation-card.njk
+++ b/docs/components/court-cases-release-dates/latest-calculation-card.njk
@@ -7,7 +7,7 @@
 {% set activeSideNav = 'latest-calculation-card' %}
 
 {% set dpsCalculation = {
-    calculatedAt: "2024-06-01",
+    calculatedAt: "2024-06-01T10:30:45",
     establishment: "HMP Kirkham",
     reason: "Transfer check",
     source: "CRDS",
@@ -47,7 +47,7 @@
 } %}
 
 {% set nomisCalculation = {
-    calculatedAt: "2024-06-01",
+    calculatedAt: "2024-06-01T10:30:45",
     reason: "Transfer check",
     source: "NOMIS",
     dates: [
@@ -102,7 +102,7 @@
     {% highlight "njk" %}
         {% raw %}
 {% set dpsCalculation = {
-    calculatedAt: "2024-06-01",
+    calculatedAt: "2024-06-01T10:30:45",
     establishment: "HMP Kirkham",
     reason: "Transfer check",
     source: "CRDS",
@@ -142,7 +142,7 @@
 } %}
 
 {% set nomisCalculation = {
-    calculatedAt: "2024-06-01",
+    calculatedAt: "2024-06-01T10:30:45",
     reason: "Transfer check",
     source: "NOMIS",
     dates: [

--- a/src/hmpps/@types/index.ts
+++ b/src/hmpps/@types/index.ts
@@ -67,8 +67,8 @@ export interface SubNavigation {
 
 export interface LatestCalculationCardConfig {
   /**
-   * Format: date
-   * @example 1975-04-02
+   * Format: date or timestamp
+   * @example 1975-04-02 or 1975-04-02T10:30:45
    */
   calculatedAt: string
   establishment?: string

--- a/src/hmpps/utils/utils.ts
+++ b/src/hmpps/utils/utils.ts
@@ -1,4 +1,4 @@
-import { format, isValid, parse } from 'date-fns'
+import { format, isValid, parse, parseISO } from 'date-fns'
 
 const uniformWhitespace = (word: string): string => (word ? word.trim().replace(/\s+/g, ' ') : '')
 
@@ -40,6 +40,6 @@ export const personStatus = (status: string): string => sentenceCase(status)
 
 export const hmppsFormatDate = (dateString: string, pattern: string): string => {
   if (!dateString) return ''
-  const date = parse(dateString, 'yyyy-MM-dd', new Date())
+  const date = parseISO(dateString)
   return date && isValid(date) ? format(date, pattern) : dateString
 }

--- a/test/hmpps/components/court-cases-release-dates/latest-calculation-card/latestCalculationCard.test.ts
+++ b/test/hmpps/components/court-cases-release-dates/latest-calculation-card/latestCalculationCard.test.ts
@@ -16,7 +16,7 @@ const action: Action = { title: 'My action', href: '/my-action', dataQa: 'my-act
 describe('Tests for latest calculation date component', () => {
   it('Card title should just be the date and reason if there is no establishment (NOMIS or early CRD)', () => {
     const latestCalculation: LatestCalculationCardConfig = {
-      calculatedAt: '2024-06-01',
+      calculatedAt: '2024-06-01T10:30:45',
       reason: 'Transfer check',
       source: 'NOMIS',
       dates: [],
@@ -31,9 +31,26 @@ describe('Tests for latest calculation date component', () => {
     expect(titleLines[0]).toStrictEqual('01 June 2024')
     expect(titleLines[1]).toStrictEqual('Calculation reason: Transfer check')
   })
+  it('Card title should support date only format for calculated at', () => {
+    const latestCalculation: LatestCalculationCardConfig = {
+      calculatedAt: '2024-06-15',
+      reason: 'Transfer check',
+      source: 'NOMIS',
+      dates: [],
+    }
+    const content = nunjucks.render('index.njk', { latestCalculation })
+    const $ = cheerio.load(content)
+    const titleLines = $('.govuk-summary-card__title')
+      .text()
+      .split('\n')
+      .map(str => str.trim())
+      .filter(str => str.length > 0)
+    expect(titleLines[0]).toStrictEqual('15 June 2024')
+    expect(titleLines[1]).toStrictEqual('Calculation reason: Transfer check')
+  })
   it('Card title should include the establishment if there is one', () => {
     const latestCalculation: LatestCalculationCardConfig = {
-      calculatedAt: '2024-06-01',
+      calculatedAt: '2024-06-01T10:30:45',
       establishment: 'HMP Kirkham',
       reason: 'Transfer check',
       source: 'CRDS',
@@ -51,7 +68,7 @@ describe('Tests for latest calculation date component', () => {
   })
   it('NOMIS calculation should NOMIS badge with no action', () => {
     const latestCalculation: LatestCalculationCardConfig = {
-      calculatedAt: '2024-06-01',
+      calculatedAt: '2024-06-01T10:30:45',
       reason: 'Transfer check',
       source: 'NOMIS',
       dates: [],
@@ -63,7 +80,7 @@ describe('Tests for latest calculation date component', () => {
   })
   it('DPS calculation should not show badge even with no action', () => {
     const latestCalculation: LatestCalculationCardConfig = {
-      calculatedAt: '2024-06-01',
+      calculatedAt: '2024-06-01T10:30:45',
       reason: 'Transfer check',
       source: 'CRDS',
       dates: [],
@@ -75,7 +92,7 @@ describe('Tests for latest calculation date component', () => {
   })
   it('DPS calculation should show action if specified', () => {
     const latestCalculation: LatestCalculationCardConfig = {
-      calculatedAt: '2024-06-01',
+      calculatedAt: '2024-06-01T10:30:45',
       reason: 'Transfer check',
       source: 'CRDS',
       dates: [],
@@ -90,7 +107,7 @@ describe('Tests for latest calculation date component', () => {
   })
   it('Should show all dates with their description', () => {
     const latestCalculation: LatestCalculationCardConfig = {
-      calculatedAt: '2024-06-01',
+      calculatedAt: '2024-06-01T10:30:45',
       reason: 'Transfer check',
       source: 'CRDS',
       dates: [
@@ -122,7 +139,7 @@ describe('Tests for latest calculation date component', () => {
   })
   it('Should show hints for a date', () => {
     const latestCalculation: LatestCalculationCardConfig = {
-      calculatedAt: '2024-06-01',
+      calculatedAt: '2024-06-01T10:30:45',
       reason: 'Transfer check',
       source: 'CRDS',
       dates: [
@@ -155,7 +172,7 @@ describe('Tests for latest calculation date component', () => {
   })
   it('Should show hints with a policy link', () => {
     const latestCalculation: LatestCalculationCardConfig = {
-      calculatedAt: '2024-06-01',
+      calculatedAt: '2024-06-01T10:30:45',
       reason: 'Transfer check',
       source: 'CRDS',
       dates: [

--- a/test/hmpps/utils/utils.test.ts
+++ b/test/hmpps/utils/utils.test.ts
@@ -101,6 +101,7 @@ describe('format using date string', () => {
     ['Not a date', 'dd LLLL yyyy', 'Not a date'],
     ['1978-10-23', 'dd LLLL yyyy', '23 October 1978'],
     ['1982-06-15', 'cccc, dd LLLL yyyy', 'Tuesday, 15 June 1982'],
+    ['1982-06-15T15:30:45', 'cccc, dd LLLL yyyy', 'Tuesday, 15 June 1982'],
     ['1982-06-15', 'dd/MM/yyyy', '15/06/1982'],
   ])("hmppsFormatDate('%s', '%s') returns %s", (dateString: string, format: string, expected: string) => {
     expect(hmppsFormatDate(dateString, format)).toEqual(expected)


### PR DESCRIPTION
NOMIS provides a timestamp and not just a date. Changed filter to support any ISO formatted dates. Fixes latest calc card