### PR TITLE
CRS-2471: Move off bitnami image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,13 @@
-FROM bitnami/nginx:1.25.3
+FROM nginxinc/nginx-unprivileged
 
-WORKDIR /app
+USER root
 
-COPY ./_site .
+ARG user=apppuser
+ARG uid=1001
+RUN addgroup --gid ${uid} ${user} && \
+    adduser --disabled-login --disabled-password --ingroup ${user} --home /${user} --gecos "${user} user" --shell /bin/bash --uid ${uid} ${user} && \
+    usermod -a -G ${user} nginx
+
+COPY ./_site /usr/share/nginx/html
+
+USER ${uid}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginxinc/nginx-unprivileged
+FROM nginxinc/nginx-unprivileged:1.29.1-bookworm
 
 USER root
 


### PR DESCRIPTION
Use nginxinc/nginx-unprivileged instead.  It is used for the intranet and other MoJ services and should be able to run in the locked down k8s clusters as it's not run as root.